### PR TITLE
resolve callbacks for cut/copy/paste interactions

### DIFF
--- a/packages/spreadsheet/src/Spreadsheet.tsx
+++ b/packages/spreadsheet/src/Spreadsheet.tsx
@@ -1623,6 +1623,14 @@ const Spreadsheet: React.FC<SpreadSheetProps & RefAttributeSheetGrid> = memo(
           columnIndex,
           columnIndex + (rows.length && rows[0].length - 1)
         );
+        const newSelection = {
+          bounds: {
+            top: rowIndex,
+            left: columnIndex,
+            bottom: endRowIndex,
+            right: endColumnIndex,
+          }
+        }
 
         dispatch({
           type: ACTION_TYPE.PASTE,
@@ -1636,7 +1644,7 @@ const Spreadsheet: React.FC<SpreadSheetProps & RefAttributeSheetGrid> = memo(
         cellChangeCallback(
           id,
           activeCell,
-          selection === void 0 ? void 0 : [selection]
+          selection === void 0 ? [newSelection] : [selection, newSelection]
         );
 
         if (activeCell) {
@@ -1647,16 +1655,7 @@ const Spreadsheet: React.FC<SpreadSheetProps & RefAttributeSheetGrid> = memo(
         /* Should select */
         if (rowIndex === endRowIndex && columnIndex === endColumnIndex) return;
 
-        currentGrid.current?.setSelections([
-          {
-            bounds: {
-              top: rowIndex,
-              left: columnIndex,
-              bottom: endRowIndex,
-              right: endColumnIndex,
-            },
-          },
-        ]);
+        currentGrid.current?.setSelections([newSelection]);
       },
       []
     );


### PR DESCRIPTION
This branch fixes an issue with the handlePaste callback functionality. Currently, handlePaste is used for both cuts and copies, but needs to handle these interactions differently. The current callback functionality is not correctly reflecting the changes for either cuts or copies.   

For cut & paste, both cut area and paste area should be marked as changed. However, current functionality only marks the 'cut area' as changed, and not the 'paste area'.
For copy & paste, only paste area should be marked as changed. Current functionality does not mark the 'paste area' as changed, instead 'selection' which is passed to cellChangeCallback is undefined, so only one cell gets returned as changed in the callback.  

With this patch, I believe the correct cell changes are sent to onChangeCells callback in all cases. 