### PR TITLE
fix: shift + wheel scroll doesn't work

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1447,7 +1447,7 @@ const Grid: React.FC<GridProps & RefAttribute> = memo(
       /* Scroll natively */
       if (wheelingRef.current) return;
 
-      let dx = isScrollingHorizontally ? deltaY : deltaX;
+      let dx = deltaX;
       let dy = deltaY;
 
       /* Scroll only in one direction */


### PR DESCRIPTION
Hi, thank you for such a nice package. I really appreciate it 😁

However I noticed that horizontal scroll with mouse wheel(shift + wheelScroll) doesn't make any scroll, even if there's a handler for it. So I made a small commit to fix it.

I hope this PR will help..

*Tested on MacOS Ventura 13.4, Chrome