### PR TITLE
Remove unused "inProgress" prop

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -2194,7 +2194,6 @@ const Grid: React.FC<GridProps & RefAttribute> = memo(
                 ? selectionStrokeWidth
                 : 0,
             selection,
-            inProgress,
           })
         );
       }
@@ -2217,7 +2216,6 @@ const Grid: React.FC<GridProps & RefAttribute> = memo(
                 ? selectionStrokeWidth
                 : 0,
             selection,
-            inProgress,
           })
         );
       }
@@ -2250,7 +2248,6 @@ const Grid: React.FC<GridProps & RefAttribute> = memo(
                 ? selectionStrokeWidth
                 : 0,
             selection,
-            inProgress,
           })
         );
       }
@@ -2264,7 +2261,6 @@ const Grid: React.FC<GridProps & RefAttribute> = memo(
           width: selectionBounds.width,
           height: selectionBounds.height,
           selection,
-          inProgress,
         })
       );
 

--- a/packages/grid/src/hooks/useEditable.tsx
+++ b/packages/grid/src/hooks/useEditable.tsx
@@ -527,14 +527,7 @@ const useEditable = ({
         currentActiveCellRef.current = coords;
 
         /* Get offsets */
-        const containerOffset =
-          gridRef.current.container?.getBoundingClientRect();
-        const cellPos = gridRef.current.getCellOffsetFromCoords(coords);
-        const pos = {
-          ...cellPos,
-          x: (containerOffset?.x ?? 0) + (cellPos.x ?? 0),
-          y: (containerOffset?.y ?? 0) + (cellPos.y ?? 0),
-        };
+        const pos = gridRef.current.getCellOffsetFromCoords(coords);
         const scrollPosition = gridRef.current.getScrollPosition();
         const cellValue = getValueRef.current(coords);
         const value = initialValue || cellValue || "";

--- a/packages/grid/src/hooks/useEditable.tsx
+++ b/packages/grid/src/hooks/useEditable.tsx
@@ -527,7 +527,14 @@ const useEditable = ({
         currentActiveCellRef.current = coords;
 
         /* Get offsets */
-        const pos = gridRef.current.getCellOffsetFromCoords(coords);
+        const containerOffset =
+          gridRef.current.container?.getBoundingClientRect();
+        const cellPos = gridRef.current.getCellOffsetFromCoords(coords);
+        const pos = {
+          ...cellPos,
+          x: (containerOffset?.x ?? 0) + (cellPos.x ?? 0),
+          y: (containerOffset?.y ?? 0) + (cellPos.y ?? 0),
+        };
         const scrollPosition = gridRef.current.getScrollPosition();
         const cellValue = getValueRef.current(coords);
         const value = initialValue || cellValue || "";


### PR DESCRIPTION
I am getting errors about the `inProgress` prop in my NextJS application using Grid. 
It seems like the prop is being passed by accident as the `Selection` component is not using it and therefore passes it as a regular attribute.

<img width="712" alt="Screenshot 2024-11-12 at 09 41 18" src="https://github.com/user-attachments/assets/a4177953-9602-4687-a37b-3f541c7117d7">
